### PR TITLE
Adding 2022-2024 presentations to website

### DIFF
--- a/content/present.Rmd
+++ b/content/present.Rmd
@@ -2,6 +2,28 @@
 title: "Presentations"
 ---
 
+## 2024
+
+-   May
+    -   PharmaSUG: [Validating R for Pharma](https://github.com/pharmaR/events/blob/main/pharmaSUG_2024/PharmaSUG_SI269_Slides.pptx), *Anuja Das*
+
+## 2023
+
+-   October
+    -   R/Pharma: [Updates from the R Validation Hub: Toward a Pharma Repository](https://github.com/pharmaR/events/blob/main/Rpharma2023/slides/RPharma2023.html), *Juliane Manitz, Coline Zeballos*
+-   September
+    -   posit::conf(2023): [R Validation Hub Status Report and Workshop](https://pharmar.github.io/events-positconf2023/#/title-slide), *Doug Kelkhoff*
+-   June
+    -   AZ R Conference: [It's time to integrate the R into PhaRma](https://github.com/pharmaR/events/tree/main/AZ_R_conf_2023), *Lyn Taylor*
+-   March
+    -   ShinyConf 2023: [{riskassessment} for R-Package Validation](https://github.com/pharmaR/events/blob/main/shinyConf_2023/riskassessment_ClarkAaron_shinyConf2023.pdf), *Aaron Clark*
+    -   R Adoption Series: [Learnings and Reflection from RvalHub Case Studies](https://github.com/pharmaR/events/blob/main/R_Adoption_Series_2023/Manitz_RvalHub_case_study_summaries_2023.pdf) ([recording](https://github.com/pharmaR/events/tree/main?tab=readme-ov-file)), *Juliane Manitz, Doug Kelkhoff, Uday Preetham Palakuru, Eric Milliman*
+
+## 2022
+
+-   June
+    -   useR! Conference: [Implementation of Risk Assessment for R Packages: Learnings and Reflection](https://github.com/pharmaR/events/blob/main/useR_2022/Manitz_useR_2022.pdf)
+
 ## 2021
 
 -   November

--- a/content/present.html
+++ b/content/present.html
@@ -5,6 +5,46 @@ title: "Presentations"
 
 
 <div id="section" class="section level2">
+<h2>2024</h2>
+<ul>
+<li>May
+<ul>
+<li>PharmaSUG: <a href="https://github.com/pharmaR/events/blob/main/pharmaSUG_2024/PharmaSUG_SI269_Slides.pptx">Validating R for Pharma</a>, <em>Anuja Das</em></li>
+</ul></li>
+</ul>
+</div>
+<div id="section-1" class="section level2">
+<h2>2023</h2>
+<ul>
+<li>October
+<ul>
+<li>R/Pharma: <a href="https://github.com/pharmaR/events/blob/main/Rpharma2023/slides/RPharma2023.html">Updates from the R Validation Hub: Toward a Pharma Repository</a>, <em>Juliane Manitz, Coline Zeballos</em></li>
+</ul></li>
+<li>September
+<ul>
+<li>posit::conf(2023): <a href="https://pharmar.github.io/events-positconf2023/#/title-slide">R Validation Hub Status Report and Workshop</a>, <em>Doug Kelkhoff</em></li>
+</ul></li>
+<li>June
+<ul>
+<li>AZ R Conference: <a href="https://github.com/pharmaR/events/tree/main/AZ_R_conf_2023">It’s time to integrate the R into PhaRma</a>, <em>Lyn Taylor</em></li>
+</ul></li>
+<li>March
+<ul>
+<li>ShinyConf 2023: <a href="https://github.com/pharmaR/events/blob/main/shinyConf_2023/riskassessment_ClarkAaron_shinyConf2023.pdf">{riskassessment} for R-Package Validation</a>, <em>Aaron Clark</em></li>
+<li>R Adoption Series: <a href="https://github.com/pharmaR/events/blob/main/R_Adoption_Series_2023/Manitz_RvalHub_case_study_summaries_2023.pdf">Learnings and Reflection from RvalHub Case Studies</a> (<a href="https://github.com/pharmaR/events/tree/main?tab=readme-ov-file">recording</a>), <em>Juliane Manitz, Doug Kelkhoff, Uday Preetham Palakuru, Eric Milliman</em></li>
+</ul></li>
+</ul>
+</div>
+<div id="section-2" class="section level2">
+<h2>2022</h2>
+<ul>
+<li>June
+<ul>
+<li>useR! Conference: <a href="https://github.com/pharmaR/events/blob/main/useR_2022/Manitz_useR_2022.pdf">Implementation of Risk Assessment for R Packages: Learnings and Reflection</a></li>
+</ul></li>
+</ul>
+</div>
+<div id="section-3" class="section level2">
 <h2>2021</h2>
 <ul>
 <li><p>November</p>
@@ -78,7 +118,7 @@ title: "Presentations"
 </ul></li>
 </ul>
 </div>
-<div id="section-1" class="section level2">
+<div id="section-4" class="section level2">
 <h2>2020</h2>
 <ul>
 <li><p><a href="https://pharmar.github.io/rpharma2020_pres/">R/Pharma 2020 Presentation</a>, October, <em>Andy Nicholls</em></p>
@@ -91,7 +131,7 @@ title: "Presentations"
 <li><p><a href="/presentations/eu_prog_heads.pdf">EU Programming Heads meeting</a>, June, <em>Andy Nicholls</em></p></li>
 </ul>
 </div>
-<div id="section-2" class="section level2">
+<div id="section-5" class="section level2">
 <h2>2019</h2>
 <ul>
 <li><a href="/presentations/rpharma_2019.pdf">R/Pharma 2019 workshop</a>, August, <em>Andy Nicholls, Sean Lopp</em>
@@ -101,7 +141,7 @@ title: "Presentations"
 <li><a href="/presentations/validation_hub.pdf">PSI Conference - progress update</a>, June, <em>Andy Nicholls</em></li>
 </ul>
 </div>
-<div id="section-3" class="section level2">
+<div id="section-6" class="section level2">
 <h2>2018</h2>
 <ul>
 <li><a href="/presentations/R_Validation_Workshop.pdf">R in Pharma workshop</a>, August, <em>Andy Nicholls</em></li>
@@ -110,7 +150,7 @@ title: "Presentations"
 </div>
 <div id="news-articles" class="section level2">
 <h2>News Articles</h2>
-<div id="section-4" class="section level3">
+<div id="section-7" class="section level3">
 <h3>2019</h3>
 <ul>
 <li><a href="/presentations/spin_r_validation.pdf">PSI SPIN Article</a></li>


### PR DESCRIPTION
Added presentations for our 2022-2024 presentations we have had. This way, our website can be more up to date.

_Note: links to slides are sometimes to our events repo, which we plan on making public by end of this month._